### PR TITLE
fix null pattern

### DIFF
--- a/base_limiter.go
+++ b/base_limiter.go
@@ -34,7 +34,7 @@ func NewBaseLimiter(
 	targetExtensionsMap := make(map[string]struct{}, len(targetExtensions))
 	if len(targetExtensions) > 0 {
 		for _, ext := range targetExtensions {
-			if ext[0] != '.' {
+			if len(ext) > 0 && ext[0] != '.' {
 				ext = "." + ext
 			}
 			targetExtensionsMap[strings.ToLower(ext)] = struct{}{}

--- a/base_limiter_test.go
+++ b/base_limiter_test.go
@@ -54,6 +54,12 @@ func TestBaseLimiter_isTargetExtensions(t *testing.T) {
 			requestPath:      "/file",
 			want:             false,
 		},
+		{
+			name:             "null extention",
+			targetExtensions: []string{""},
+			requestPath:      "/file",
+			want:             true,
+		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
ref: https://go.dev/play/p/2vZE4pIC-ai

In Go, accessing a[0] when a is an empty string (a := "") will result in a panic.